### PR TITLE
Apply markdown linting only to added-or-changed mdfiles

### DIFF
--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -40,21 +40,15 @@ jobs:
         uses: actions/checkout@v3 # Do we actually need main?
         with:
           fetch-depth: 2 # Ensures we have the history to determine changed files
-      # - name: Install markdown-link-check
-      #   run: npm install -g markdown-link-check
       - name: Fetch the base branch
         run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - name: Get changed markdown files
-        id: get-changed-files
-        run: |
-          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
-          echo "files=$files" >> "$GITHUB_OUTPUT"
-      - name: markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          base-branch: ${{ github.base_ref }}
-          check-modified-files-only: 'yes'
-          use-verbose-mode: 'yes'
+      # - name: Install markdown-link-check
+      #   run: npm install -g markdown-link-check
+      # - name: Get changed markdown files
+      #   id: get-changed-files
+      #   run: |
+      #     files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
+      #     echo "files=$files" >> "$GITHUB_OUTPUT"
       # - name: Check links in changed Markdown files
       #   run: |
       #     files="${{ steps.get-changed-files.outputs.files }}"
@@ -64,3 +58,9 @@ jobs:
       #         markdown-link-check "$file"
       #       fi
       #     done
+      - name: markdown-link-check
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          base-branch: ${{ github.base_ref }}
+          check-modified-files-only: 'yes'
+          # use-verbose-mode: 'yes'

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -15,11 +15,12 @@ jobs:
       - name: Get changed markdown files
         id: get-changed-files
         run: |
-          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md' | tr '\n' ' ')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Install/run markdown link checker against changed markdown files
         run: |
-          mds="${{ steps.get-changed-files.outputs.files }}"
+          files="${{ steps.get-changed-files.outputs.files }}"
+          IFS=' ' read -r -a mds <<< "$files"
           if [ ${#mds[@]} -ne 0 ]; then
             npm install -g markdown-link-check
             for mdf in "${mds[@]}"; do

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -24,7 +24,7 @@ jobs:
             npm install -g markdown-link-check
             for mdf in "${mds[@]}"; do
                 echo "Linkchecking $mdf ..."
-                markdownlint "$mdf"
+                markdown-link-check "$mdf"
             done
           fi
       # - name: Check links in changed markdown files

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Get changed markdown files
         id: get-changed-files
         run: |
-          echo "Finding changed markdown files..."
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Check links in changed Markdown files

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -1,33 +1,3 @@
-# ---
-# on:
-#   workflow_call:
-
-# jobs:
-#   markdown-link-checker:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Check out code
-#         uses: actions/checkout@main
-#       - name: Pull Change list
-#         id: changed-files
-#         uses: collin-miller/git-changesets@master
-#       - name: Verify Changed files
-#         id: verify-changed-files
-#         run: |
-#           echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
-#           if grep ".*\.md" changed.txt; then
-#             echo "files_changed=true" >> "$GITHUB_OUTPUT"
-#           else
-#             echo "files_changed=false" >> "$GITHUB_OUTPUT"
-#           fi
-#       - name: markdown-link-check
-#         if: steps.verify-changed-files.outputs.files_changed == 'true'
-#         uses: gaurav-nelson/github-action-markdown-link-check@master
-#         with:
-#           base-branch: 'main'
-#           check-modified-files-only: 'yes'
-# #          use-verbose-mode: "yes"
-
 ---
 on:
   workflow_call:
@@ -42,25 +12,24 @@ jobs:
           fetch-depth: 2 # Ensures we have the history to determine changed files
       - name: Fetch the base branch
         run: git fetch --depth=1 origin ${{ github.base_ref }}
-      # - name: Install markdown-link-check
-      #   run: npm install -g markdown-link-check
-      # - name: Get changed markdown files
-      #   id: get-changed-files
-      #   run: |
-      #     files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
-      #     echo "files=$files" >> "$GITHUB_OUTPUT"
+      - name: Get changed markdown files
+        id: get-changed-files
+        run: |
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+      - name: Install/run markdown link checker against changed markdown files
+        run: |
+          mds="${{ steps.get-changed-files.outputs.files }}"
+          if [ ${#mds[@]} -ne 0 ]; then
+            npm install -g markdown-link-check
+            for mdf in "${mds[@]}"; do
+                echo "Linkchecking $mdf ..."
+                markdownlint "$mdf"
+            done
+          fi
       # - name: Check links in changed markdown files
-      #   run: |
-      #     files="${{ steps.get-changed-files.outputs.files }}"
-      #     for file in $files; do
-      #       if [ -f "$file" ]; then
-      #         echo "Checking $file"
-      #         markdown-link-check "$file"
-      #       fi
-      #     done
-      - name: Check links in changed markdown files
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          base-branch: ${{ github.base_ref }}
-          check-modified-files-only: 'yes'
-          # use-verbose-mode: 'yes'
+      #   uses: gaurav-nelson/github-action-markdown-link-check@v1
+      #   with:
+      #     base-branch: ${{ github.base_ref }}
+      #     check-modified-files-only: 'yes'
+      #     # use-verbose-mode: 'yes'

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3 # Do we actually need main?
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2 # Ensures we have the history to determine changed files
       - name: Fetch the base branch
@@ -49,7 +49,7 @@ jobs:
       #   run: |
       #     files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
       #     echo "files=$files" >> "$GITHUB_OUTPUT"
-      # - name: Check links in changed Markdown files
+      # - name: Check links in changed markdown files
       #   run: |
       #     files="${{ steps.get-changed-files.outputs.files }}"
       #     for file in $files; do
@@ -58,7 +58,7 @@ jobs:
       #         markdown-link-check "$file"
       #       fi
       #     done
-      - name: markdown-link-check
+      - name: Check links in changed markdown files
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           base-branch: ${{ github.base_ref }}

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -1,3 +1,33 @@
+# ---
+# on:
+#   workflow_call:
+
+# jobs:
+#   markdown-link-checker:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Check out code
+#         uses: actions/checkout@main
+#       - name: Pull Change list
+#         id: changed-files
+#         uses: collin-miller/git-changesets@master
+#       - name: Verify Changed files
+#         id: verify-changed-files
+#         run: |
+#           echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
+#           if grep ".*\.md" changed.txt; then
+#             echo "files_changed=true" >> "$GITHUB_OUTPUT"
+#           else
+#             echo "files_changed=false" >> "$GITHUB_OUTPUT"
+#           fi
+#       - name: markdown-link-check
+#         if: steps.verify-changed-files.outputs.files_changed == 'true'
+#         uses: gaurav-nelson/github-action-markdown-link-check@master
+#         with:
+#           base-branch: 'main'
+#           check-modified-files-only: 'yes'
+# #          use-verbose-mode: "yes"
+
 ---
 on:
   workflow_call:
@@ -7,23 +37,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@main
-      - name: Pull Change list
-        id: changed-files
-        uses: collin-miller/git-changesets@master
-      - name: Verify Changed files
-        id: verify-changed-files
-        run: |
-          echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
-          if grep ".*\.md" changed.txt; then
-            echo "files_changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "files_changed=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: markdown-link-check
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
-        uses: gaurav-nelson/github-action-markdown-link-check@master
+        uses: actions/checkout@v3 # Do we actually need main?
         with:
-          base-branch: 'main'
-          check-modified-files-only: 'yes'
-#          use-verbose-mode: "yes"
+          fetch-depth: 2 # Ensures we have the history to determine changed files
+      - name: Install markdown-link-check
+        run: npm install -g markdown-link-check
+      - name: Fetch the base branch
+        run: git fetch --depth=1 origin ${{ github.base_ref }}
+      - name: Get changed markdown files
+        id: get-changed-files
+        run: |
+          echo "Finding changed markdown files..."
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
+          echo "::set-output name=files::$files"
+      - name: Check links in changed Markdown files
+        run: |
+          files="${{ steps.get-changed-files.outputs.files }}"
+          for file in $files; do
+            if [ -f "$file" ]; then
+              echo "Checking $file"
+              markdown-link-check "$file"
+            fi
+          done

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -42,8 +42,8 @@ jobs:
         #   fetch-depth: 2 # Ensures we have the history to determine changed files
       # - name: Install markdown-link-check
       #   run: npm install -g markdown-link-check
-      # - name: Fetch the base branch
-      #   run: git fetch --depth=1 origin ${{ github.base_ref }}
+      - name: Fetch the base branch
+        run: git fetch --depth=1 origin ${{ github.base_ref }}
       - name: Get changed markdown files
         id: get-changed-files
         run: |

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "Finding changed markdown files..."
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
-          echo "::set-output name=files::$files"
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Check links in changed Markdown files
         run: |
           files="${{ steps.get-changed-files.outputs.files }}"

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -28,9 +28,3 @@ jobs:
                 markdown-link-check "$mdf"
             done
           fi
-      # - name: Check links in changed markdown files
-      #   uses: gaurav-nelson/github-action-markdown-link-check@v1
-      #   with:
-      #     base-branch: ${{ github.base_ref }}
-      #     check-modified-files-only: 'yes'
-      #     # use-verbose-mode: 'yes'

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -23,5 +23,7 @@ jobs:
       - name: markdown-link-check
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         uses: gaurav-nelson/github-action-markdown-link-check@master
-#        with:
+        with:
+          base-branch: 'main'
+          check-modified-files-only: 'yes'
 #          use-verbose-mode: "yes"

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3 # Do we actually need main?
-        # with:
-        #   fetch-depth: 2 # Ensures we have the history to determine changed files
+        with:
+          fetch-depth: 2 # Ensures we have the history to determine changed files
       # - name: Install markdown-link-check
       #   run: npm install -g markdown-link-check
       - name: Fetch the base branch
@@ -50,7 +50,7 @@ jobs:
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@master
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           base-branch: ${{ github.base_ref }}
           check-modified-files-only: 'yes'

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -38,23 +38,29 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3 # Do we actually need main?
-        with:
-          fetch-depth: 2 # Ensures we have the history to determine changed files
-      - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
-      - name: Fetch the base branch
-        run: git fetch --depth=1 origin ${{ github.base_ref }}
+        # with:
+        #   fetch-depth: 2 # Ensures we have the history to determine changed files
+      # - name: Install markdown-link-check
+      #   run: npm install -g markdown-link-check
+      # - name: Fetch the base branch
+      #   run: git fetch --depth=1 origin ${{ github.base_ref }}
       - name: Get changed markdown files
         id: get-changed-files
         run: |
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
           echo "files=$files" >> "$GITHUB_OUTPUT"
-      - name: Check links in changed Markdown files
-        run: |
-          files="${{ steps.get-changed-files.outputs.files }}"
-          for file in $files; do
-            if [ -f "$file" ]; then
-              echo "Checking $file"
-              markdown-link-check "$file"
-            fi
-          done
+      - name: markdown-link-check
+        uses: gaurav-nelson/github-action-markdown-link-check@master
+        with:
+          base-branch: ${{ github.base_ref }}
+          check-modified-files-only: 'yes'
+          use-verbose-mode: 'yes'
+      # - name: Check links in changed Markdown files
+      #   run: |
+      #     files="${{ steps.get-changed-files.outputs.files }}"
+      #     for file in $files; do
+      #       if [ -f "$file" ]; then
+      #         echo "Checking $file"
+      #         markdown-link-check "$file"
+      #       fi
+      #     done

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -50,10 +50,10 @@ jobs:
       - name: Checkout Code
         # uses: actions/checkout@main
         uses: actions/checkout@v3 # Do we actually need main?
-        with:
-          fetch-depth: 2 # Ensures we have the history to determine changed files
-      - name: Fetch the base branch
-        run: git fetch --depth=1 origin ${{ github.base_ref }}
+        # with:
+        #   fetch-depth: 2 # Ensures we have the history to determine changed files
+      # - name: Fetch the base branch
+      #   run: git fetch --depth=1 origin ${{ github.base_ref }}
       - name: Get changed markdown files
         id: get-changed-files
         run: |

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -45,7 +45,7 @@ on:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
-    container: ruby:alpine
+    # container: ruby:alpine
     steps:
       - name: Checkout Code
         # uses: actions/checkout@main
@@ -57,7 +57,6 @@ jobs:
       - name: Get changed markdown files
         id: get-changed-files
         run: |
-          echo "Finding changed markdown files..."
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run Markdown Linter

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -45,7 +45,7 @@ on:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
-    # container: ruby:alpine
+    container: ruby:alpine
     steps:
       - name: Checkout Code
         # uses: actions/checkout@main

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -45,11 +45,9 @@ on:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
-    # container: ruby:alpine
     steps:
-      - name: Checkout Code
-        # uses: actions/checkout@main
-        uses: actions/checkout@v3 # Do we actually need main?
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2 # Ensures we have the history to determine changed files
       - name: Fetch the base branch
@@ -59,7 +57,7 @@ jobs:
         run: |
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
           echo "files=$files" >> "$GITHUB_OUTPUT"
-      - name: Install/run Markdown Linter
+      - name: Install/run markdown linter against changed markdown files
         run: |
           mds="${{ steps.get-changed-files.outputs.files }}"
           if [ ${#mds[@]} -ne 0 ]; then

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -52,8 +52,8 @@ jobs:
         uses: actions/checkout@v3 # Do we actually need main?
         # with:
         #   fetch-depth: 2 # Ensures we have the history to determine changed files
-      # - name: Fetch the base branch
-      #   run: git fetch --depth=1 origin ${{ github.base_ref }}
+      - name: Fetch the base branch
+        run: git fetch --depth=1 origin ${{ github.base_ref }}
       - name: Get changed markdown files
         id: get-changed-files
         run: |

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo "Finding changed markdown files..."
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
-          echo "::set-output name=files::$files"
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run Markdown Linter
         run: |
           mds="${{ steps.get-changed-files.outputs.files }}"

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,43 +1,3 @@
-# ---
-# on:
-#   workflow_call:
-
-# jobs:
-#   markdown-lint:
-#     runs-on: ubuntu-latest
-#     container: ruby:alpine
-#     steps:
-#       - name: Checkout Code
-#         uses: actions/checkout@main
-#       - name: Pull Change list
-#         id: changed-files
-#         uses: collin-miller/git-changesets@master
-#       - name: Verify Changed files
-#         id: verify-changed-files
-#         run: |
-#           echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
-#           if grep ".*\.md" changed.txt; then
-#             echo "files_changed=true" >> "$GITHUB_OUTPUT"
-#           else
-#             echo "files_changed=false" >> "$GITHUB_OUTPUT"
-#           fi
-#       - name: Run Markdown Linter
-#         if: steps.verify-changed-files.outputs.files_changed == 'true'
-#         run: |
-#           echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
-#           declare -a mds
-#           while read -r f; do
-#             if [[ "$f" =~ \.md ]]; then
-#               mds+=("$f")
-#             fi
-#           done <changed.txt
-#           if [ ${#mds[@]} -ne 0 ]; then
-#             gem install mdl
-#             for mdf in "${mds[@]}"; do
-#                 mdl "$mdf"
-#             done
-#           fi
-
 ---
 on:
   workflow_call:
@@ -63,6 +23,7 @@ jobs:
           if [ ${#mds[@]} -ne 0 ]; then
             npm install -g markdownlint-cli
             for mdf in "${mds[@]}"; do
+                echo "Linting $mdf ..."
                 markdownlint "$mdf"
             done
           fi

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -15,11 +15,12 @@ jobs:
       - name: Get changed markdown files
         id: get-changed-files
         run: |
-          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md' | tr '\n' ' ')
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Install/run markdown linter against changed markdown files
         run: |
-          mds="${{ steps.get-changed-files.outputs.files }}"
+          files="${{ steps.get-changed-files.outputs.files }}"
+          IFS=' ' read -r -a mds <<< "$files"
           if [ ${#mds[@]} -ne 0 ]; then
             npm install -g markdownlint-cli
             for mdf in "${mds[@]}"; do

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -45,7 +45,7 @@ on:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
-    container: ruby:alpine
+    # container: ruby:alpine
     steps:
       - name: Checkout Code
         # uses: actions/checkout@main
@@ -59,12 +59,12 @@ jobs:
         run: |
           files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
           echo "files=$files" >> "$GITHUB_OUTPUT"
-      - name: Run Markdown Linter
+      - name: Install/run Markdown Linter
         run: |
           mds="${{ steps.get-changed-files.outputs.files }}"
           if [ ${#mds[@]} -ne 0 ]; then
-            gem install mdl
+            npm install -g markdownlint-cli
             for mdf in "${mds[@]}"; do
-                mdl "$mdf"
+                markdownlint "$mdf"
             done
           fi

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,3 +1,43 @@
+# ---
+# on:
+#   workflow_call:
+
+# jobs:
+#   markdown-lint:
+#     runs-on: ubuntu-latest
+#     container: ruby:alpine
+#     steps:
+#       - name: Checkout Code
+#         uses: actions/checkout@main
+#       - name: Pull Change list
+#         id: changed-files
+#         uses: collin-miller/git-changesets@master
+#       - name: Verify Changed files
+#         id: verify-changed-files
+#         run: |
+#           echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
+#           if grep ".*\.md" changed.txt; then
+#             echo "files_changed=true" >> "$GITHUB_OUTPUT"
+#           else
+#             echo "files_changed=false" >> "$GITHUB_OUTPUT"
+#           fi
+#       - name: Run Markdown Linter
+#         if: steps.verify-changed-files.outputs.files_changed == 'true'
+#         run: |
+#           echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
+#           declare -a mds
+#           while read -r f; do
+#             if [[ "$f" =~ \.md ]]; then
+#               mds+=("$f")
+#             fi
+#           done <changed.txt
+#           if [ ${#mds[@]} -ne 0 ]; then
+#             gem install mdl
+#             for mdf in "${mds[@]}"; do
+#                 mdl "$mdf"
+#             done
+#           fi
+
 ---
 on:
   workflow_call:
@@ -8,29 +48,21 @@ jobs:
     container: ruby:alpine
     steps:
       - name: Checkout Code
-        uses: actions/checkout@main
-      - name: Pull Change list
-        id: changed-files
-        uses: collin-miller/git-changesets@master
-      - name: Verify Changed files
-        id: verify-changed-files
+        # uses: actions/checkout@main
+        uses: actions/checkout@v3 # Do we actually need main?
+        with:
+          fetch-depth: 2 # Ensures we have the history to determine changed files
+      - name: Fetch the base branch
+        run: git fetch --depth=1 origin ${{ github.base_ref }}
+      - name: Get changed markdown files
+        id: get-changed-files
         run: |
-          echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
-          if grep ".*\.md" changed.txt; then
-            echo "files_changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "files_changed=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "Finding changed markdown files..."
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
+          echo "::set-output name=files::$files"
       - name: Run Markdown Linter
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: |
-          echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
-          declare -a mds
-          while read -r f; do
-            if [[ "$f" =~ \.md ]]; then
-              mds+=("$f")
-            fi
-          done <changed.txt
+          mds="${{ steps.get-changed-files.outputs.files }}"
           if [ ${#mds[@]} -ne 0 ]; then
             gem install mdl
             for mdf in "${mds[@]}"; do

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -24,5 +24,16 @@ jobs:
       - name: Run Markdown Linter
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: |
-          gem install mdl
-          find . -type f -iname "*.md" -exec mdl \{\} \+
+          echo '${{ steps.changed-files.outputs.added_modified }}' > changed.txt
+          declare -a mds
+          while read -r f; do
+            if [[ "$f" =~ \.md ]]; then
+              mds+=("$f")
+            fi
+          done <changed.txt
+          if [ ${#mds[@]} -ne 0 ]; then
+            gem install mdl
+            for mdf in "${mds[@]}"; do
+                mdl "$mdf"
+            done
+          fi

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Checkout Code
         # uses: actions/checkout@main
         uses: actions/checkout@v3 # Do we actually need main?
-        # with:
-        #   fetch-depth: 2 # Ensures we have the history to determine changed files
+        with:
+          fetch-depth: 2 # Ensures we have the history to determine changed files
       - name: Fetch the base branch
         run: git fetch --depth=1 origin ${{ github.base_ref }}
       - name: Get changed markdown files


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Previously, if an exception was made to merge a PR with failing checks on md files, this would result in all subsequent PRs failing on the same checks as linting was run across all files rather than only those changed/relevant in the branch to be merged. These changes should fix that (only for md files)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
