### PR TITLE
ci(git-changesets): update version from master -> v3

### DIFF
--- a/.github/workflows/chef-data_bags-deploy.yml
+++ b/.github/workflows/chef-data_bags-deploy.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/chef-policyfiles-deploy.yml
+++ b/.github/workflows/chef-policyfiles-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/cookbook-supermarket-deploy.yml
+++ b/.github/workflows/cookbook-supermarket-deploy.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/cookstyle-lint.yml
+++ b/.github/workflows/cookstyle-lint.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/shellcheck-lint.yml
+++ b/.github/workflows/shellcheck-lint.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/xml-lint.yml
+++ b/.github/workflows/xml-lint.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@main
       - name: Pull Change list
         id: changed-files
-        uses: collin-miller/git-changesets@master
+        uses: collin-miller/git-changesets@v3
       - name: Verify Changed files
         id: verify-changed-files
         run: |


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Updating git-changesets to use the v3 install instead of the old default branch.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This will resolve the dependency on the legacy default branch. If this or a similar change is not merged the workflows will break.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
